### PR TITLE
Fix react e2es

### DIFF
--- a/e2e/react-core/src/react-package.test.ts
+++ b/e2e/react-core/src/react-package.test.ts
@@ -37,6 +37,7 @@ describe('Build React libraries and apps', () => {
   let proj: string;
 
   beforeEach(async () => {
+    process.env.NX_ADD_PLUGINS = 'false';
     app = uniq('app');
     parentLib = uniq('parentlib');
     childLib = uniq('childlib');
@@ -109,6 +110,7 @@ describe('Build React libraries and apps', () => {
   afterEach(() => {
     killPorts();
     cleanupProject();
+    delete process.env.NX_ADD_PLUGINS;
   });
 
   describe('Buildable libraries', () => {

--- a/e2e/react-core/src/react.test.ts
+++ b/e2e/react-core/src/react.test.ts
@@ -218,14 +218,18 @@ describe('React Applications', () => {
     runCLI(`g @nx/react:redux orange --project=${libName} --skipFormat`);
 
     let lintResults = runCLI(`lint ${appName}`);
-    expect(lintResults).toContain('All files pass linting.');
+    expect(lintResults).toContain(
+      `Successfully ran target lint for project ${appName}`
+    );
     const appTestResults = await runCLIAsync(`test ${appName}`);
     expect(appTestResults.combinedOutput).toContain(
       'Test Suites: 2 passed, 2 total'
     );
 
     lintResults = runCLI(`lint ${libName}`);
-    expect(lintResults).toContain('All files pass linting.');
+    expect(lintResults).toContain(
+      `Successfully ran target lint for project ${libName}`
+    );
     const libTestResults = await runCLIAsync(`test ${libName}`);
     expect(libTestResults.combinedOutput).toContain(
       'Test Suites: 2 passed, 2 total'

--- a/e2e/react-core/src/react.test.ts
+++ b/e2e/react-core/src/react.test.ts
@@ -443,7 +443,9 @@ async function testGeneratedApp(
 ) {
   if (opts.checkLinter) {
     const lintResults = runCLI(`lint ${appName}`);
-    expect(lintResults).toContain('All files pass linting.');
+    expect(lintResults).toContain(
+      `Successfully ran target lint for project ${appName}`
+    );
   }
 
   runCLI(

--- a/e2e/react-module-federation/src/react-module-federation.test.ts
+++ b/e2e/react-module-federation/src/react-module-federation.test.ts
@@ -440,11 +440,15 @@ describe('React Module Federation', () => {
     let tree: Tree;
 
     beforeAll(() => {
+      process.env.NX_ADD_PLUGINS = 'false';
       tree = createTreeWithEmptyWorkspace();
       proj = newProject();
     });
 
-    afterAll(() => cleanupProject());
+    afterAll(() => {
+      cleanupProject();
+      delete process.env.NX_ADD_PLUGINS;
+    });
 
     it('should support promised based remotes', async () => {
       const remote = uniq('remote');

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -18,7 +18,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
   };
 
   if (options.bundler === 'webpack') {
-    if (!hasWebpackPlugin(host)) {
+    if (!hasWebpackPlugin(host) || !options.addPlugin) {
       project.targets = {
         build: createBuildTarget(options),
         serve: createServeTarget(options),

--- a/packages/react/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/react/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -105,13 +105,13 @@ export default config;
 `;
 
 exports[`hostGenerator should generate host files and configs when --typescriptConfiguration=true 1`] = `
-"import {composePlugins, withNx} from '@nx/webpack';
+"import {composePlugins, withNx, ModuleFederationConfig} from '@nx/webpack';
 import {withReact} from '@nx/react';
 import {withModuleFederation} from '@nx/react/module-federation';
 
 import baseConfig from './module-federation.config';
 
-const config = {
+const config: ModuleFederationConfig = {
     ...baseConfig,
 };
 

--- a/packages/react/src/generators/host/files/module-federation-ts/webpack.config.prod.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/webpack.config.prod.ts__tmpl__
@@ -1,10 +1,11 @@
 import { composePlugins, withNx } from '@nx/webpack';
 import { withReact } from '@nx/react';
 import { withModuleFederation } from '@nx/react/module-federation';
+import { ModuleFederationConfig } from '@nx/webpack';
 
 import baseConfig from './module-federation.config';
 
-const prodConfig = {
+const prodConfig: ModuleFederationConfig = {
     ...baseConfig,
     /*
      * Remote overrides for production.

--- a/packages/react/src/generators/host/files/module-federation-ts/webpack.config.ts__tmpl__
+++ b/packages/react/src/generators/host/files/module-federation-ts/webpack.config.ts__tmpl__
@@ -1,10 +1,10 @@
-import {composePlugins, withNx} from '@nx/webpack';
+import {composePlugins, withNx, ModuleFederationConfig} from '@nx/webpack';
 import {withReact} from '@nx/react';
 import {withModuleFederation} from '@nx/react/module-federation';
 
 import baseConfig from './module-federation.config';
 
-const config = {
+const config: ModuleFederationConfig = {
     ...baseConfig,
 };
 

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -41,6 +41,8 @@ export async function hostGeneratorInternal(
     ...(await normalizeOptions<Schema>(host, schema, '@nx/react:host')),
     typescriptConfiguration: schema.typescriptConfiguration ?? true,
     dynamic: schema.dynamic ?? false,
+    // TODO(colum): remove when MF works with Crystal
+    addPlugin: false,
   };
 
   const initTask = await applicationGenerator(host, {

--- a/packages/react/src/generators/host/schema.d.ts
+++ b/packages/react/src/generators/host/schema.d.ts
@@ -26,10 +26,12 @@ export interface Schema {
   minimal?: boolean;
   typescriptConfiguration?: boolean;
   dynamic?: boolean;
+  addPlugin?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {
   appProjectRoot: string;
   e2eProjectName: string;
   projectName: string;
+  addPlugin?: boolean;
 }

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -75,6 +75,8 @@ export async function remoteGeneratorInternal(host: Tree, schema: Schema) {
     ...(await normalizeOptions<Schema>(host, schema, '@nx/react:remote')),
     typescriptConfiguration: schema.typescriptConfiguration ?? false,
     dynamic: schema.dynamic ?? false,
+    // TODO(colum): remove when MF works with Crystal
+    addPlugin: false,
   };
   const initAppTask = await applicationGenerator(host, {
     ...options,

--- a/packages/react/src/module-federation/with-module-federation-ssr.ts
+++ b/packages/react/src/module-federation/with-module-federation-ssr.ts
@@ -4,6 +4,10 @@ import { getModuleFederationConfig } from './utils';
 export async function withModuleFederationForSSR(
   options: ModuleFederationConfig
 ) {
+  if (global.NX_GRAPH_CREATION) {
+    return (config) => config;
+  }
+
   const { sharedLibraries, sharedDependencies, mappedRemotes } =
     await getModuleFederationConfig(options, {
       isServer: true,

--- a/packages/react/src/module-federation/with-module-federation.ts
+++ b/packages/react/src/module-federation/with-module-federation.ts
@@ -13,6 +13,9 @@ const isVarOrWindow = (libType?: string) =>
 export async function withModuleFederation(
   options: ModuleFederationConfig
 ): Promise<AsyncNxComposableWebpackPlugin> {
+  if (global.NX_GRAPH_CREATION) {
+    return (config) => config;
+  }
   const { sharedDependencies, sharedLibraries, mappedRemotes } =
     await getModuleFederationConfig(options);
   const isGlobal = isVarOrWindow(options.library?.type);


### PR DESCRIPTION

- Adds `process.env.NX_ADD_PLUGINS` to react-package test, as it uses executor-only features
- Fixes expected log from linting for react-core
- Fixes MF generators to force creation of project.json targets