### PR TITLE
fix(docs): correct typo 'layed' to 'laid' in nx-17-2-release blog post

### DIFF
--- a/docs/blog/2023-12-20-nx-17-2-release.md
+++ b/docs/blog/2023-12-20-nx-17-2-release.md
@@ -36,7 +36,7 @@ Adoption is crucial, and simplicity is the driver for adoption. Last year we hea
 
 Using Nx at that level is definitely useful as you get intelligent parallelization, task pipelines and caching. But it is just the tip of the iceberg of what Nx is actually capable of. Nx plugins provide much more, especially in terms of DX and developer productivity by taking away some of the burden of configuring your monorepo tooling. But many devs new to Nx found it harder to get started with them initially and incrementally migrating to Nx plugins wasn't as straightforward as we'd wanted it to be.
 
-This is something that's gonna change drastically in 2024. And we've layed the first cornerstone for that. But it is behind a feature flag still as we're streamlining the last bits. The goal?
+This is something that's gonna change drastically in 2024. And we've laid the first cornerstone for that. But it is behind a feature flag still as we're streamlining the last bits. The goal?
 
 - Going almost configuration-less (good defaults, you customize when you need to)
 - Allowing easy drop-in of Nx plugins into existing workspaces (provides immediate productivity gains, but stays out of your way)

--- a/docs/blog/2024-02-15-launch-week-recap.md
+++ b/docs/blog/2024-02-15-launch-week-recap.md
@@ -118,7 +118,7 @@ Tusky will also be able to provide organizational-level insights to your codebas
 
 Versioning and publishing packages is always a bit tricky. Mix in the added complexity of having multiple packages — sometimes with different versioning or publishing strategies — inside the same codebase, and things can get weird quick!
 
-For a long time, Nx has been purposefully versioning and publishing agnostic, but given our time spent as [stewards of Lerna](/blog/lerna-is-dead-long-live-lerna) (the OG Javascript monorepo tool), we've been able to take alot of that experience and finally feel confident creating our own versioning and publishing implementation.
+For a long time, Nx has been purposefully versioning and publishing agnostic, but given our time spent as [stewards of Lerna](/blog/lerna-is-dead-long-live-lerna) (the OG Javascript monorepo tool), we've been able to take a lot of that experience and finally feel confident creating our own versioning and publishing implementation.
 
 Therefore, we've been working on a new command to the Nx CLI: [nx release](/recipes/nx-release/get-started-with-nx-release#get-started-with-nx-release). We launched this on Friday of our Launch Nx week!
 


### PR DESCRIPTION
## Current Behavior
The nx-17-2-release blog post contains a typo where "layed" is used instead of the correct past tense "laid".

## Expected Behavior
The blog post should use the correct spelling "laid" in the phrase "And we've laid the first cornerstone for that."

## Related Issue(s)
Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)