### PR TITLE
fix: correct typo "layed" to "laid" in nx-17-2-release blog post

### DIFF
--- a/docs/blog/2023-12-20-nx-17-2-release.md
+++ b/docs/blog/2023-12-20-nx-17-2-release.md
@@ -36,7 +36,7 @@ Adoption is crucial, and simplicity is the driver for adoption. Last year we hea
 
 Using Nx at that level is definitely useful as you get intelligent parallelization, task pipelines and caching. But it is just the tip of the iceberg of what Nx is actually capable of. Nx plugins provide much more, especially in terms of DX and developer productivity by taking away some of the burden of configuring your monorepo tooling. But many devs new to Nx found it harder to get started with them initially and incrementally migrating to Nx plugins wasn't as straightforward as we'd wanted it to be.
 
-This is something that's gonna change drastically in 2024. And we've layed the first cornerstone for that. But it is behind a feature flag still as we're streamlining the last bits. The goal?
+This is something that's gonna change drastically in 2024. And we've laid the first cornerstone for that. But it is behind a feature flag still as we're streamlining the last bits. The goal?
 
 - Going almost configuration-less (good defaults, you customize when you need to)
 - Allowing easy drop-in of Nx plugins into existing workspaces (provides immediate productivity gains, but stays out of your way)


### PR DESCRIPTION
Fixes a typo in the Nx 17.2 release blog post where "layed" should be "laid".

**Changes:**
- Fixed typo in `docs/blog/2023-12-20-nx-17-2-release.md` on line 39
- Changed "And we've layed the first cornerstone for that." to "And we've laid the first cornerstone for that."

Fixes #19

Generated with [Claude Code](https://claude.ai/code)